### PR TITLE
Add new state 'ready-for-transfer' and file reuse logic for data source

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -17,7 +17,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install packages
 RUN apt-get update && \
-    apt-get dist-upgrade && \
+    apt-get dist-upgrade -y && \
     apt-get install -y cmake wget curl git less file \
         libglib2.0-dev libkmod-dev libnl-genl-3-dev linux-libc-dev pkg-config psmisc tox qemu-utils fuse python-dev \
         devscripts debhelper bash-completion librdmacm-dev libibverbs-dev xsltproc docbook-xsl \

--- a/pkg/datasource/handler.go
+++ b/pkg/datasource/handler.go
@@ -108,7 +108,7 @@ func (s *Service) UpdateProgress(processedSize int64) {
 	if s.state == types.StateStarting {
 		s.state = types.StateInProgress
 	}
-	if s.state == types.StateReady {
+	if s.state == types.StateReady || s.state == types.StateReadyForTransfer {
 		return
 	}
 
@@ -159,7 +159,7 @@ func (s *Service) finishProcessing(err error) {
 	s.size = stat.Size()
 	s.processedSize = stat.Size()
 	s.progress = 100
-	s.state = types.StateReady
+	s.state = types.StateReadyForTransfer
 	s.lock.Unlock()
 
 	return

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -28,11 +28,12 @@ const (
 type State string
 
 const (
-	StatePending    = State("pending")
-	StateStarting   = State("starting")
-	StateInProgress = State("in-progress")
-	StateReady      = State("ready")
-	StateFailed     = State("failed")
+	StatePending          = State("pending")
+	StateStarting         = State("starting")
+	StateInProgress       = State("in-progress")
+	StateReadyForTransfer = State("ready-for-transfer")
+	StateReady            = State("ready")
+	StateFailed           = State("failed")
 )
 
 type DataSourceType string


### PR DESCRIPTION
This means a file becomes ready but it's still not picked by the
backing image manager as well as not ready for replicas.

longhorn/longhorn#2530