### PR TITLE
Fix staticcheck

### DIFF
--- a/pkg/server/backing_image.go
+++ b/pkg/server/backing_image.go
@@ -184,7 +184,6 @@ func (bi *BackingImage) Receive(senderManagerAddress string, portAllocateFunc fu
 		bi.lock.Lock()
 		bi.finishFileProcessingWithoutLock(err)
 		bi.lock.Unlock()
-		return
 	}()
 	go bi.waitForProcessingStartWithLock()
 
@@ -507,7 +506,6 @@ func (bi *BackingImage) finishFileProcessingWithoutLock(err error) {
 	}
 
 	log.Infof("Backing Image: backing image file is ready")
-	return
 }
 
 func (bi *BackingImage) UpdateSyncFileProgress(size int64) {

--- a/pkg/server/manager.go
+++ b/pkg/server/manager.go
@@ -369,19 +369,19 @@ func (m *Manager) releasePorts(start, end int32) error {
 
 func ParsePortRange(portRange string) (int32, int32, error) {
 	if portRange == "" {
-		return 0, 0, fmt.Errorf("Empty port range")
+		return 0, 0, fmt.Errorf("empty port range")
 	}
 	parts := strings.Split(portRange, "-")
 	if len(parts) != 2 {
-		return 0, 0, fmt.Errorf("Invalid format for range: %s", portRange)
+		return 0, 0, fmt.Errorf("invalid format for range: %s", portRange)
 	}
 	portStart, err := strconv.Atoi(strings.TrimSpace(parts[0]))
 	if err != nil {
-		return 0, 0, fmt.Errorf("Invalid start port for range: %s", err)
+		return 0, 0, fmt.Errorf("invalid start port for range: %s", err)
 	}
 	portEnd, err := strconv.Atoi(strings.TrimSpace(parts[1]))
 	if err != nil {
-		return 0, 0, fmt.Errorf("Invalid end port for range: %s", err)
+		return 0, 0, fmt.Errorf("invalid end port for range: %s", err)
 	}
 	return int32(portStart), int32(portEnd), nil
 }

--- a/pkg/server/manager.go
+++ b/pkg/server/manager.go
@@ -191,8 +191,6 @@ func (m *Manager) unregisterBackingImage(bi *BackingImage) {
 	defer m.lock.Unlock()
 
 	delete(m.backingImages, bi.Name)
-
-	return
 }
 
 func (m *Manager) findBackingImage(name string) *BackingImage {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -132,18 +133,18 @@ func (s *TestSuite) TestManagerSyncAndFetch(c *C) {
 					FromHost: "from-host-" + strconv.Itoa(i),
 					ToHost:   "to-host-" + strconv.Itoa(i),
 				}
-				syncResp, err := s.m.Sync(nil, syncReq)
+				syncResp, err := s.m.Sync(context.TODO(), syncReq)
 				c.Assert(err, IsNil)
 				c.Assert(syncResp.Status.State, Not(Equals), string(types.StateFailed))
 
-				getResp, err := s.m.Get(nil, &rpc.GetRequest{
+				getResp, err := s.m.Get(context.TODO(), &rpc.GetRequest{
 					Name: name,
 				})
 				c.Assert(err, IsNil)
 				c.Assert(getResp.Spec.Name, Equals, name)
 				c.Assert(getResp.Status.State, Not(Equals), string(types.StateFailed))
 
-				listResp, err := s.m.List(nil, &empty.Empty{})
+				listResp, err := s.m.List(context.TODO(), &empty.Empty{})
 				c.Assert(err, IsNil)
 				c.Assert(listResp.BackingImages[name], NotNil)
 				c.Assert(listResp.BackingImages[name].Spec.Name, Equals, name)
@@ -151,7 +152,7 @@ func (s *TestSuite) TestManagerSyncAndFetch(c *C) {
 
 				isReady := false
 				for j := 0; j < RetryCount; j++ {
-					getResp, err := s.m.Get(nil, &rpc.GetRequest{
+					getResp, err := s.m.Get(context.TODO(), &rpc.GetRequest{
 						Name: name,
 					})
 					c.Assert(err, IsNil)
@@ -179,11 +180,11 @@ func (s *TestSuite) TestManagerSyncAndFetch(c *C) {
 					},
 					SourceFileName: sourceFileName,
 				}
-				fetchResp, err := s.m.Fetch(nil, fetchReq)
+				fetchResp, err := s.m.Fetch(context.TODO(), fetchReq)
 				c.Assert(err, IsNil)
 				c.Assert(fetchResp.Status.State, Equals, string(types.StateReady))
 
-				getResp, err := s.m.Get(nil, &rpc.GetRequest{
+				getResp, err := s.m.Get(context.TODO(), &rpc.GetRequest{
 					Name: name,
 				})
 				c.Assert(err, IsNil)
@@ -198,9 +199,9 @@ func (s *TestSuite) TestManagerSyncAndFetch(c *C) {
 			deleteReq := &rpc.DeleteRequest{
 				Name: name,
 			}
-			_, err := s.m.Delete(nil, deleteReq)
+			_, err := s.m.Delete(context.TODO(), deleteReq)
 			c.Assert(err, IsNil)
-			_, err = s.m.Get(nil, &rpc.GetRequest{
+			_, err = s.m.Get(context.TODO(), &rpc.GetRequest{
 				Name: name,
 			})
 			c.Assert(err, NotNil)


### PR DESCRIPTION
Fixes some of the static check errors picked up by Sonatype Lift [here](https://lift.sonatype.com/result/longhorn/backing-image-manager/01FHW28GZJCYWXER2F3EX1XYJB?all=CustomTool%20%22Staticcheck%22).