### PR TITLE
Remove redundant return statements

### DIFF
--- a/pkg/datasource/handler.go
+++ b/pkg/datasource/handler.go
@@ -226,8 +226,6 @@ func (s *Service) finishProcessing(err error) {
 	s.progress = 100
 	s.state = types.StateReadyForTransfer
 	s.lock.Unlock()
-
-	return
 }
 
 func (s *Service) downloadFromURL(parameters map[string]string) error {

--- a/pkg/server/backing_image.go
+++ b/pkg/server/backing_image.go
@@ -184,7 +184,6 @@ func (bi *BackingImage) Receive(senderManagerAddress string, portAllocateFunc fu
 		bi.lock.Lock()
 		bi.finishFileProcessingWithoutLock(err)
 		bi.lock.Unlock()
-		return
 	}()
 	go bi.waitForProcessingStartWithLock()
 
@@ -507,7 +506,6 @@ func (bi *BackingImage) finishFileProcessingWithoutLock(err error) {
 	}
 
 	log.Infof("Backing Image: backing image file is ready")
-	return
 }
 
 func (bi *BackingImage) UpdateSyncFileProgress(size int64) {


### PR DESCRIPTION
Removing redundant return statements caught by `golint` on [Sonatype Lift](https://lift.sonatype.com/result/longhorn/backing-image-manager/01FHW28GZJCYWXER2F3EX1XYJB?s=&t=CustomTool%20%22golangci-lint%22%7Cgosimple).