### PR TITLE
Adding s390x arch for HEAD images

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -308,6 +308,7 @@ steps:
     platforms:
       - linux/amd64
       - linux/arm64
+      - linux/s390x
     target: "longhornio/backing-image-manager:${DRONE_BRANCH}-head"
     template: "longhornio/backing-image-manager:${DRONE_BRANCH}-head-ARCH"
   when:


### PR DESCRIPTION
Adding missing `s390x` arch for HEAD images

Signed-off-by: Luis Tovar <luis.tovar@suse.coM>