### PR TITLE
Set right longhorn repo for s390x tag step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -256,7 +256,7 @@ steps:
       from_secret: docker_username
     password:
       from_secret: docker_password
-    repo: rancherlabs/longhornonz-backing-image-manager
+    repo: longhornio/backing-image-manager
     tag: "${DRONE_TAG}-s390x"
   volumes:
     - name: socket


### PR DESCRIPTION
Replaced Longhorn repo for `s390x` tag step
Signed-off-by: Luis Tovar <luis.tovar@suse.coM>