### PR TITLE
fix: fix typo to fix backing image sync retry failure

### DIFF
--- a/pkg/sync/sync_file.go
+++ b/pkg/sync/sync_file.go
@@ -635,7 +635,7 @@ func (sf *SyncingFile) finishProcessingNoLock(err error) (finalErr error) {
 
 	stat, statErr := os.Stat(sf.tmpFilePath)
 	if statErr != nil {
-		finalErr = errors.Wrapf(err, "failed to stat tmp file %v after getting the file from source", sf.tmpFilePath)
+		finalErr = errors.Wrapf(statErr, "failed to stat tmp file %v after getting the file from source", sf.tmpFilePath)
 		return
 	}
 	if stat.Size() != sf.processedSize {


### PR DESCRIPTION
[longhorn/longhorn#5481](https://github.com/longhorn/longhorn/issues/5481)

The failure is caused by the typo.
When the folder is locked, sync server won't be able to init the sync file (tmp) in the folder and will close the server and return. But since server close is expected when operation succeed, we ignore the server close err, so the err is nil now.

Then it goes to defer function `finishProcessingNoLock`.
`os.Stat` function will return error since there is no tmp file but the following  `errors.Wrapf` use `err` instead of `statErr` and got `nil` for finalErr.

Thus make `handleFailureNoLock` defer function doesn't handle the error correctly.

```
stat, statErr := os.Stat(sf.tmpFilePath)
	if statErr != nil {
		finalErr = errors.Wrapf(err, "failed to stat tmp file %v after getting the file from source", sf.tmpFilePath)
		return
	}
```