### PR TITLE
Lh5443 fix uploading checksum time consuming issue

### DIFF
--- a/pkg/sync/server_test.go
+++ b/pkg/sync/server_test.go
@@ -386,7 +386,7 @@ func (s *SyncTestSuite) TestFetch(c *C) {
 	err = cli.Forget(curPath)
 	c.Assert(err, IsNil)
 
-	// Reusing the existing file without the config file would skip the checksum calculation.
+	// Reusing the existing file with the config file would skip the checksum calculation.
 	err = cli.Fetch(curPath, curPath, TestSyncingFileUUID, TestDiskUUID, checksum, sizeInMB*MB)
 	c.Assert(err, IsNil)
 	_, err = getAndWaitFileState(cli, curPath, string(types.StateReady), 3)


### PR DESCRIPTION
[longhorn/longhorn#5443](https://github.com/longhorn/longhorn/issues/5443)

When after syncing file there is a post-processing function `finishProcessing` which will get file checksum and write config.
`GetFileChecksum` may be time consuming and can lead to client timeout if file is large.

This PR move it to a goroutine to make the api return to client first. After calculating the checksum, it will still update the state of syncfile to ready and then Longhorn will automatically do the following job (e.g. transfer file to manager)
