### PR TITLE
BackingImage does not download URL correctly in some situation

### DIFF
--- a/pkg/sync/handler.go
+++ b/pkg/sync/handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -39,7 +40,7 @@ func (h *HTTPHandler) GetSizeFromURL(url string) (size int64, err error) {
 		return 0, err
 	}
 
-	client := http.Client{}
+	client := NewDownloadHttpClient()
 	resp, err := client.Do(rr)
 	if err != nil {
 		return 0, err
@@ -72,7 +73,7 @@ func (h *HTTPHandler) DownloadFromURL(ctx context.Context, url, filePath string,
 		return 0, err
 	}
 
-	client := http.Client{}
+	client := NewDownloadHttpClient()
 	resp, err := client.Do(rr)
 	if err != nil {
 		return 0, err
@@ -174,6 +175,27 @@ func IdleTimeoutCopy(ctx context.Context, cancel context.CancelFunc, src io.Read
 	}
 
 	return copied, err
+}
+
+func removeReferer(req *http.Request) {
+	for k := range req.Header {
+		if strings.ToLower(k) == "referer" {
+			delete(req.Header, k)
+		}
+	}
+}
+
+func NewDownloadHttpClient() http.Client {
+	return http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// Remove the "Referer" header to enable downloads of files
+			// that are delivered via CDN and therefore may be redirected
+			// several times. This is the same behaviour of curl or wget
+			// in their default configuration.
+			removeReferer(req)
+			return nil
+		},
+	}
 }
 
 const (

--- a/pkg/sync/handler_test.go
+++ b/pkg/sync/handler_test.go
@@ -1,0 +1,20 @@
+package sync
+
+import (
+	. "gopkg.in/check.v1"
+	"net/http"
+)
+
+type TestSuite struct{}
+
+var _ = Suite(&TestSuite{})
+
+func (s *TestSuite) TestRemoveReferer(c *C) {
+	req, err := http.NewRequest("HEAD", "https://foo.bar", nil)
+	c.Assert(err, IsNil)
+	req.Header.Set("Referer", "https://foo.bar")
+	req.Header.Set("Foo", "foo")
+	removeReferer(req)
+	c.Assert(req.Referer(), Equals, "")
+	c.Assert(req.Header, HasLen, 1)
+}


### PR DESCRIPTION
Remove the `Referer` header that is automatically added by the http client. Without this header it is possible to download files that are redirected several times. This mimics the behaviour of `curl` and `wget` which do not submit the `Referer` header by default.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/longhorn/longhorn/issues/7914

#### What this PR does / why we need it:

This PR removes the `Referer` header from the requests. This is necessary to allow downloads of files (e.g. ISO images) that are delivered from file hosters (e.g. SourceForge) via CDN which normally results in several redirects until the requested file is downloaded.

This PR mimics the default behaviour of tools like `curl` or `wget`.
