### PR TITLE
feat: support v2 backing image download file from sync service

### DIFF
--- a/pkg/client/sync_client.go
+++ b/pkg/client/sync_client.go
@@ -186,7 +186,7 @@ func (client *SyncClient) Fetch(srcFilePath, dstFilePath, uuid, diskUUID, expect
 	return nil
 }
 
-func (client *SyncClient) DownloadFromURL(downloadURL, filePath, uuid, diskUUID, expectedChecksum string) error {
+func (client *SyncClient) DownloadFromURL(downloadURL, filePath, uuid, diskUUID, expectedChecksum, dataEngine string) error {
 	httpClient := &http.Client{Timeout: 0}
 
 	requestURL := fmt.Sprintf("http://%s/v1/files", client.Remote)
@@ -201,6 +201,7 @@ func (client *SyncClient) DownloadFromURL(downloadURL, filePath, uuid, diskUUID,
 	q.Add("uuid", uuid)
 	q.Add("disk-uuid", diskUUID)
 	q.Add("expected-checksum", expectedChecksum)
+	q.Add("data-engine", dataEngine)
 	req.URL.RawQuery = q.Encode()
 
 	resp, err := httpClient.Do(req)
@@ -220,7 +221,7 @@ func (client *SyncClient) DownloadFromURL(downloadURL, filePath, uuid, diskUUID,
 	return nil
 }
 
-func (client *SyncClient) CloneFromBackingImage(sourceBackingImage, sourceBackingImageUUID, encryption, filePath, uuid, diskUUID, expectedChecksum string, credential map[string]string) error {
+func (client *SyncClient) CloneFromBackingImage(sourceBackingImage, sourceBackingImageUUID, encryption, filePath, uuid, diskUUID, expectedChecksum string, credential map[string]string, dataEngine string) error {
 	httpClient := &http.Client{Timeout: 0}
 	encodedCredential, err := json.Marshal(credential)
 	if err != nil {
@@ -242,6 +243,7 @@ func (client *SyncClient) CloneFromBackingImage(sourceBackingImage, sourceBackin
 	q.Add("uuid", uuid)
 	q.Add("disk-uuid", diskUUID)
 	q.Add("expected-checksum", expectedChecksum)
+	q.Add("data-engine", dataEngine)
 
 	req.URL.RawQuery = q.Encode()
 
@@ -262,7 +264,7 @@ func (client *SyncClient) CloneFromBackingImage(sourceBackingImage, sourceBackin
 	return nil
 }
 
-func (client *SyncClient) RestoreFromBackupURL(backupURL, concurrentLimit, filePath, uuid, diskUUID, expectedChecksum string, credential map[string]string) error {
+func (client *SyncClient) RestoreFromBackupURL(backupURL, concurrentLimit, filePath, uuid, diskUUID, expectedChecksum string, credential map[string]string, dataEngine string) error {
 	httpClient := &http.Client{Timeout: 0}
 	encodedCredential, err := json.Marshal(credential)
 	if err != nil {
@@ -283,6 +285,7 @@ func (client *SyncClient) RestoreFromBackupURL(backupURL, concurrentLimit, fileP
 	q.Add("disk-uuid", diskUUID)
 	q.Add("expected-checksum", expectedChecksum)
 	q.Add("concurrent-limit", concurrentLimit)
+	q.Add("data-engine", dataEngine)
 
 	req.URL.RawQuery = q.Encode()
 
@@ -363,7 +366,7 @@ func (client *SyncClient) Upload(src, dst, uuid, diskUUID, expectedChecksum stri
 	return nil
 }
 
-func (client *SyncClient) Receive(filePath, uuid, diskUUID, expectedChecksum, fileType string, receiverPort int, size int64) error {
+func (client *SyncClient) Receive(filePath, uuid, diskUUID, expectedChecksum, fileType string, receiverPort int, size int64, dataEngine string) error {
 	httpClient := &http.Client{Timeout: 0}
 
 	requestURL := fmt.Sprintf("http://%s/v1/files", client.Remote)
@@ -380,6 +383,7 @@ func (client *SyncClient) Receive(filePath, uuid, diskUUID, expectedChecksum, fi
 	q.Add("file-type", fileType)
 	q.Add("port", strconv.Itoa(receiverPort))
 	q.Add("size", strconv.FormatInt(size, 10))
+	q.Add("data-engine", dataEngine)
 	req.URL.RawQuery = q.Encode()
 
 	resp, err := httpClient.Do(req)

--- a/pkg/manager/service.go
+++ b/pkg/manager/service.go
@@ -341,7 +341,7 @@ func (m *Manager) Sync(ctx context.Context, req *rpc.SyncRequest) (resp *rpc.Bac
 	}()
 
 	biFilePath := types.GetBackingImageFilePath(m.diskPath, req.Spec.Name, req.Spec.Uuid)
-	if err := m.syncClient.Receive(biFilePath, req.Spec.Uuid, m.diskUUID, req.Spec.Checksum, "", int(port), req.Spec.Size); err != nil {
+	if err := m.syncClient.Receive(biFilePath, req.Spec.Uuid, m.diskUUID, req.Spec.Checksum, "", int(port), req.Spec.Size, types.DataEnginev1); err != nil {
 		portReleaseChannel <- nil
 		return nil, err
 	}

--- a/pkg/sync/router.go
+++ b/pkg/sync/router.go
@@ -17,7 +17,7 @@ func NewRouter(service *Service) *mux.Router {
 	router.HandleFunc("/v1/files/{id}", service.Delete).Methods("DELETE")
 	router.HandleFunc("/v1/files/{id}", service.Forget).Methods("POST").Queries("action", "forget")
 	router.HandleFunc("/v1/files/{id}", service.SendToPeer).Methods("POST").Queries("action", "sendToPeer")
-	router.HandleFunc("/v1/files/{id}/download", service.DownloadToDst).Methods("GET")
+	router.HandleFunc("/v1/files/{id}/download", service.DownloadToDst).Methods("GET", "HEAD")
 
 	// Launch a new file
 	router.HandleFunc("/v1/files", service.Fetch).Methods("POST").Queries("action", "fetch")

--- a/pkg/sync/server_test.go
+++ b/pkg/sync/server_test.go
@@ -103,7 +103,7 @@ func (s *SyncTestSuite) BenchmarkMultipleDownload(c *C) {
 				Remote: s.addr,
 			}
 
-			err := cli.DownloadFromURL("http://test-download-from-url.io", curPath, curUUID, TestDiskUUID, "")
+			err := cli.DownloadFromURL("http://test-download-from-url.io", curPath, curUUID, TestDiskUUID, "", types.DataEnginev1)
 			c.Assert(err, IsNil)
 
 			_, err = getAndWaitFileState(cli, curPath, string(types.StateReady), 30)
@@ -218,7 +218,7 @@ func (s *SyncTestSuite) BenchmarkOneReceiveAndMultiSendWithSendingLimit(c *C) {
 		curUUID := TestSyncingFileUUID + "-dst-" + strconv.Itoa(i)
 		curReceiverPort := TestSyncServiceReceivePort + i
 		curReceiverAddress := fmt.Sprintf("localhost:%d", curReceiverPort)
-		err := cli.Receive(dstFilePath, curUUID, TestDiskUUID, checksum, types.SyncingFileTypeQcow2, curReceiverPort, int64(sizeInMB*MB))
+		err := cli.Receive(dstFilePath, curUUID, TestDiskUUID, checksum, types.SyncingFileTypeQcow2, curReceiverPort, int64(sizeInMB*MB), types.DataEnginev1)
 		c.Assert(err, IsNil)
 
 		err = cli.Send(originalFilePath, curReceiverAddress)
@@ -314,7 +314,7 @@ func (s *SyncTestSuite) BenchmarkMultiReceiveAndMultiSend(c *C) {
 				Remote: s.addr,
 			}
 
-			err := cli.Receive(dstFilePath, curUUID, TestDiskUUID, checksum, types.SyncingFileTypeQcow2, curReceiverPort, int64(sizeInMB*MB))
+			err := cli.Receive(dstFilePath, curUUID, TestDiskUUID, checksum, types.SyncingFileTypeQcow2, curReceiverPort, int64(sizeInMB*MB), types.DataEnginev1)
 			c.Assert(err, IsNil)
 			err = cli.Send(srcFilePath, curReceiverAddress)
 			c.Assert(err, IsNil)
@@ -350,7 +350,7 @@ func (s *SyncTestSuite) TestTimeoutReceiveFromPeers(c *C) {
 	}
 
 	go func() {
-		err := cli.Receive(curPath, TestSyncingFileUUID, TestDiskUUID, "", types.SyncingFileTypeQcow2, TestSyncServiceReceivePort, MockFileSize)
+		err := cli.Receive(curPath, TestSyncingFileUUID, TestDiskUUID, "", types.SyncingFileTypeQcow2, TestSyncServiceReceivePort, MockFileSize, types.DataEnginev1)
 		c.Assert(err, IsNil)
 	}()
 
@@ -522,7 +522,7 @@ func (s *SyncTestSuite) TestDuplicateCalls(c *C) {
 		Remote: s.addr,
 	}
 
-	err := cli.DownloadFromURL("http://test-download-from-url.io", curPath, TestSyncingFileUUID, TestDiskUUID, "")
+	err := cli.DownloadFromURL("http://test-download-from-url.io", curPath, TestSyncingFileUUID, TestDiskUUID, "", types.DataEnginev1)
 	c.Assert(err, IsNil)
 
 	_, err = getAndWaitFileState(cli, curPath, string(types.StateReady), 30)
@@ -530,13 +530,13 @@ func (s *SyncTestSuite) TestDuplicateCalls(c *C) {
 
 	// Duplicate file launching calls should error out:
 	// "resp.StatusCode(500) != http.StatusOK(200), response body content: file /root/test-dir/sync-tests/sync-download-file-for-dup-calls already exists\n"
-	err = cli.DownloadFromURL("http://test-download-from-url.io", curPath, TestSyncingFileUUID, TestDiskUUID, "")
+	err = cli.DownloadFromURL("http://test-download-from-url.io", curPath, TestSyncingFileUUID, TestDiskUUID, "", types.DataEnginev1)
 	c.Assert(err, ErrorMatches, `.*already exists[\s\S]*`)
 	err = cli.Upload(curPath, curPath, TestSyncingFileUUID, TestDiskUUID, "")
 	c.Assert(err, ErrorMatches, `.*already exists[\s\S]*`)
-	err = cli.Receive(curPath, TestDiskUUID, TestSyncingFileUUID, "", "", types.DefaultVolumeExportReceiverPort, MockFileSize)
+	err = cli.Receive(curPath, TestDiskUUID, TestSyncingFileUUID, "", "", types.DefaultVolumeExportReceiverPort, MockFileSize, types.DataEnginev1)
 	c.Assert(err, ErrorMatches, `.*already exists[\s\S]*`)
-	err = cli.DownloadFromURL("http://test-download-from-url.io", curPath+"-non-existing", TestSyncingFileUUID, TestDiskUUID, "")
+	err = cli.DownloadFromURL("http://test-download-from-url.io", curPath+"-non-existing", TestSyncingFileUUID, TestDiskUUID, "", types.DataEnginev1)
 	c.Assert(err, ErrorMatches, `.*already exists[\s\S]*`)
 
 	// Duplicate delete or forget calls won't error out
@@ -608,7 +608,7 @@ func (s *SyncTestSuite) TestReadyFileValidation(c *C) {
 		Remote: s.addr,
 	}
 
-	err := cli.DownloadFromURL("http://test-download-from-url.io", curPath, TestSyncingFileUUID, TestDiskUUID, "")
+	err := cli.DownloadFromURL("http://test-download-from-url.io", curPath, TestSyncingFileUUID, TestDiskUUID, "", types.DataEnginev1)
 	c.Assert(err, IsNil)
 
 	fInfo, err := getAndWaitFileState(cli, curPath, string(types.StateReady), 30)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -70,6 +70,9 @@ const (
 	DataSourceTypeRestoreParameterBackupURL       = "backup-url"
 	DataSourceTypeRestoreParameterConcurrentLimit = "concurrent-limit"
 	DataSourceTypeFileType                        = "file-type"
+	DataSourceTypeParameterDataEngine             = "data-engine"
+	DataEnginev1                                  = "v1"
+	DataEnginev2                                  = "v2"
 
 	DataSourceTypeExportFromVolumeParameterVolumeSize                = "volume-size"
 	DataSourceTypeExportFromVolumeParameterSnapshotName              = "snapshot-name"


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/6341

- Modify download backing image url handler for creating v2 backing image.
    - For qcow2, we will need to transform to raw first
    - We don't need to compress the data

TODO:
- [x] Handle qcow2 image, when creating qcow2 image, the checksum and the size is based on the qcow2. It will fail if we download the raw content to the spdk lvol. The checksum will not be the same.
    - pass `dataEngine` to the datasource pod
    - in the finish processing, if this is a v2 backing image, we convert it to raw and update the size and checksum


---
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- The file download route now supports both "GET" and "HEAD" methods, allowing users to retrieve headers without downloading the file.
	- Enhanced handling for file downloads, including support for different file formats and improved processing for QCOW2 files.
	- Introduced a new query parameter to control file processing behavior.
	- New constants for data engines have been added to improve configurability.

- **Bug Fixes**
	- Improved error handling and logging during file operations to ensure better user feedback in case of issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->