### PR TITLE
fix: enlarge io context timeout to avoid endless restart loop

### DIFF
--- a/pkg/sync/handler.go
+++ b/pkg/sync/handler.go
@@ -129,6 +129,7 @@ func IdleTimeoutCopy(ctx context.Context, cancel context.CancelFunc, src io.Read
 			case <-ctx.Done():
 				done = true
 			case <-t.C:
+				logrus.WithField("HTTPTimeout", types.HTTPTimeout.Seconds()).Error("IO timeout exceeded, cancel the copy")
 				cancel()
 				done = true
 			case _, writeChOpen := <-writeSeekCh:

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -22,7 +22,7 @@ const (
 	DefaultVolumeExportReceiverPort = 8002
 
 	GRPCServiceTimeout      = 1 * time.Minute
-	HTTPTimeout             = 4 * time.Second
+	HTTPTimeout             = 30 * time.Second
 	MonitorInterval         = 3 * time.Second
 	CommandExecutionTimeout = 10 * time.Second
 


### PR DESCRIPTION
longhorn-11309

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11309

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
