### PR TITLE
chore: extract qemu-img utilities to common lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/gorilla/mux v1.8.1
 	github.com/longhorn/backupstore v0.0.0-20250804022317-794abf817297
-	github.com/longhorn/go-common-libs v0.0.0-20250831092333-eaa5dddf05b8
+	github.com/longhorn/go-common-libs v0.0.0-20250905093241-e9576a7c89fa
 	github.com/longhorn/longhorn-engine v1.9.1
 	github.com/longhorn/sparse-tools v0.0.0-20250826041019-4aae87cb253a
 	github.com/longhorn/types v0.0.0-20250831081209-ea63b0b5f6e1

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/longhorn/backupstore v0.0.0-20250804022317-794abf817297 h1:KVnOHFT3wuwgyhV7/Rue8NMt13NkpIkZ3B7eVR0C8yM=
 github.com/longhorn/backupstore v0.0.0-20250804022317-794abf817297/go.mod h1:j5TiUyvRBYaSaPY/p6GIFOk1orfWcngk9hIWxDDJ5mg=
-github.com/longhorn/go-common-libs v0.0.0-20250831092333-eaa5dddf05b8 h1:4BTTTrkY/6XoibNhkdTkrh4LTB8cYGvuDhaZCan+SIc=
-github.com/longhorn/go-common-libs v0.0.0-20250831092333-eaa5dddf05b8/go.mod h1:8acAlt4F+Dgyq923/i2pNpZI+LX7XW75BpPzxe1TXJE=
+github.com/longhorn/go-common-libs v0.0.0-20250905093241-e9576a7c89fa h1:90B+2eTb+qGlmzWosRbFr0IGK48/9T5z9drEey1DRw0=
+github.com/longhorn/go-common-libs v0.0.0-20250905093241-e9576a7c89fa/go.mod h1:8acAlt4F+Dgyq923/i2pNpZI+LX7XW75BpPzxe1TXJE=
 github.com/longhorn/go-iscsi-helper v0.0.0-20250628151415-4c3f08918bb0 h1:TwtCNOqppvJcYjQqBx7nKTITjNQoZgBD/E63whWj4Mk=
 github.com/longhorn/go-iscsi-helper v0.0.0-20250628151415-4c3f08918bb0/go.mod h1:Cmtm777Xa2TNs50+ipLMiYshVWtKsaFKbpWX/PKBgFM=
 github.com/longhorn/longhorn-engine v1.9.1 h1:DlkcXhwmR2b6ATwZeaQr8hG4i8Mf4SLcXcIzgnl6jaI=

--- a/pkg/backingimage/backingimage.go
+++ b/pkg/backingimage/backingimage.go
@@ -6,16 +6,20 @@ import (
 	"os"
 	"sync"
 
-	"github.com/longhorn/backing-image-manager/pkg/types"
-	"github.com/longhorn/backing-image-manager/pkg/util"
+	"github.com/rancher/go-fibmap"
+	"github.com/sirupsen/logrus"
+
 	"github.com/longhorn/backupstore"
 	"github.com/longhorn/backupstore/common"
+	"github.com/longhorn/sparse-tools/sparse"
+
+	imageutil "github.com/longhorn/go-common-libs/backingimage"
+
 	enginetypes "github.com/longhorn/longhorn-engine/pkg/types"
 	engineutil "github.com/longhorn/longhorn-engine/pkg/util"
 	diskutil "github.com/longhorn/longhorn-engine/pkg/util/disk"
-	"github.com/longhorn/sparse-tools/sparse"
-	"github.com/rancher/go-fibmap"
-	"github.com/sirupsen/logrus"
+
+	"github.com/longhorn/backing-image-manager/pkg/types"
 )
 
 const (
@@ -185,7 +189,7 @@ func OpenBackingImage(path string) (*BackingImage, error) {
 		return nil, err
 	}
 
-	imgInfo, err := util.GetQemuImgInfo(file)
+	imgInfo, err := imageutil.NewQemuImgExecutor().GetImageInfo(file)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sync/server_test.go
+++ b/pkg/sync/server_test.go
@@ -16,8 +16,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/longhorn/backing-image-manager/api"
+	imageutil "github.com/longhorn/go-common-libs/backingimage"
 
+	"github.com/longhorn/backing-image-manager/api"
 	"github.com/longhorn/backing-image-manager/pkg/client"
 	"github.com/longhorn/backing-image-manager/pkg/types"
 	"github.com/longhorn/backing-image-manager/pkg/util"
@@ -507,7 +508,7 @@ func (s *SyncTestSuite) TestDownloadToDst(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(downloadChecksum, Equals, checksum)
 	// Downloaded file can be identified as a qcow2 file as well.
-	downloadFileInfo, err := util.GetQemuImgInfo(unzipDownloadFilePath)
+	downloadFileInfo, err := imageutil.NewQemuImgExecutor().GetImageInfo(unzipDownloadFilePath)
 	c.Assert(err, IsNil)
 	c.Assert(downloadFileInfo.Format, Equals, "qcow2")
 }
@@ -843,7 +844,7 @@ func createQcow2File(filePath string, sizeInGB int64) error {
 	// by default". The least worst workaround for this I could think of
 	// is using `dd` to stick an extra 512 byte block of zeros on the end
 	// if the file size isn't evenly divisible by 512.
-	err := exec.Command(util.QemuImgBinary, "create", "-f", "qcow2", filePath, strconv.FormatInt(sizeInGB, 10)+"G").Run()
+	_, err := imageutil.NewQemuImgExecutor().Exec([]string{}, "create", "-f", "qcow2", filePath, strconv.FormatInt(sizeInGB, 10)+"G")
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/longhorn/go-common-libs/backingimage/backingimage.go
+++ b/vendor/github.com/longhorn/go-common-libs/backingimage/backingimage.go
@@ -1,0 +1,81 @@
+package backingimage
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/longhorn/go-common-libs/exec"
+)
+
+const (
+	QemuImgBinary = "qemu-img"
+)
+
+type ImageInfo struct {
+	Format string `json:"format"`
+
+	// physical image file size on disk
+	ActualSize int64 `json:"actual-size"`
+	// claimed size of the guest disk.
+	// For qcow2 files, VirtualSize may be larger than the physical image file size on disk.
+	// For raw files, `qemu-img info` will report VirtualSize as being the same as the ActualSize.
+	VirtualSize int64 `json:"virtual-size"`
+}
+
+type QemuImgExecutor struct {
+	exec exec.ExecuteInterface
+}
+
+func NewQemuImgExecutor() *QemuImgExecutor {
+	return newQemuImgExecutor(exec.NewExecutor())
+}
+
+func newQemuImgExecutor(exec exec.ExecuteInterface) *QemuImgExecutor {
+	return &QemuImgExecutor{exec: exec}
+}
+
+func (ex *QemuImgExecutor) Exec(envs []string, args ...string) (string, error) {
+	return ex.exec.Execute(envs, QemuImgBinary, args, time.Minute)
+}
+
+func (ex *QemuImgExecutor) GetImageInfo(filePath string) (imgInfo ImageInfo, err error) {
+
+	/* Example command outputs
+	   $ qemu-img info --output=json SLE-Micro.x86_64-5.5.0-Default-qcow-GM.qcow2
+	   {
+	       "virtual-size": 21474836480,
+	       "filename": "SLE-Micro.x86_64-5.5.0-Default-qcow-GM.qcow2",
+	       "cluster-size": 65536,
+	       "format": "qcow2",
+	       "actual-size": 1001656320,
+	       "format-specific": {
+	           "type": "qcow2",
+	           "data": {
+	               "compat": "1.1",
+	               "compression-type": "zlib",
+	               "lazy-refcounts": false,
+	               "refcount-bits": 16,
+	               "corrupt": false,
+	               "extended-l2": false
+	           }
+	       },
+	       "dirty-flag": false
+	   }
+
+	   $ qemu-img info --output=json SLE-15-SP5-Full-x86_64-GM-Media1.iso
+	   {
+	       "virtual-size": 14548992000,
+	       "filename": "SLE-15-SP5-Full-x86_64-GM-Media1.iso",
+	       "format": "raw",
+	       "actual-size": 14548996096,
+	       "dirty-flag": false
+	   }
+	*/
+
+	output, err := ex.Exec([]string{}, "info", "--output=json", filePath)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal([]byte(output), &imgInfo)
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -172,8 +172,9 @@ github.com/longhorn/backupstore/s3
 github.com/longhorn/backupstore/types
 github.com/longhorn/backupstore/util
 github.com/longhorn/backupstore/vfs
-# github.com/longhorn/go-common-libs v0.0.0-20250831092333-eaa5dddf05b8
+# github.com/longhorn/go-common-libs v0.0.0-20250905093241-e9576a7c89fa
 ## explicit; go 1.24.0
+github.com/longhorn/go-common-libs/backingimage
 github.com/longhorn/go-common-libs/backup
 github.com/longhorn/go-common-libs/bitmap
 github.com/longhorn/go-common-libs/exec


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11362

#### What this PR does / why we need it:

Refactor and extract the qemu-img related utilities to common lib.

#### Special notes for your reviewer:

depends on PR longhorn/go-common-libs/pull/132

#### Additional documentation or context
